### PR TITLE
✨ Add toolbar customisation options

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,17 +4,26 @@
 
 Y.A.M.D.E - yet another markdown editor.
 
-**Demo:** [View on Codesandbox.io](https://codesandbox.io/s/modest-framework-6zmgb?file=/src/App.js)
+**Demo:**
+
+[![View YAMDE demo](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/modest-framework-6zmgb?fontsize=14&hidenavigation=1&theme=dark)
+
+---
 
 ### 🌱 Features
 
 - Responsive
 - Light/dark mode support
+- Customizable toolbar
 - Lightweight: [Bundlephobia](https://bundlephobia.com/result?p=yamde)
+
+---
 
 ### 🔧 Installation
 
 `npm install yamde`
+
+---
 
 ### 💻 Usage
 
@@ -31,11 +40,16 @@ export const App = () => {
 }
 ```
 
-### 🎨 Themes
+---
 
-There are two available themes: `light` and `dark`.
+### ⚙️ Options
 
+#### 🎨 Themes
+
+There are two available theme: `dark` and `light`.
 This can be controlled via the `theme` prop (defaults to `light` if non specified).
+
+**Light**
 
 ```jsx
 <Yamde value={text} handler={setText} theme="light" />
@@ -43,8 +57,37 @@ This can be controlled via the `theme` prop (defaults to `light` if non specifie
 
 ![CleanShot 2021-04-15 at 00 26 39](https://user-images.githubusercontent.com/69169115/114793141-a6d12b00-9d81-11eb-9005-828d5ed6c931.gif)
 
+**Dark**
+
 ```jsx
 <Yamde value={text} handler={setText} theme="dark" />
 ```
 
 ![CleanShot 2021-04-15 at 00 28 50](https://user-images.githubusercontent.com/69169115/114793167-b5b7dd80-9d81-11eb-9ca9-c8c2a90e27c0.gif)
+
+#### ⌨️ Toolbar actions
+
+You can customize the toolbar actions by passing in the `toolbar` prop (`toolbar?: string[]`).
+Omiting this prop will default to showing all available actions.
+
+```jsx
+<Yamde value={text} handler={setText} toolbar={['bold', 'italic', 'strikethrough']} />
+```
+
+Available actions:
+
+| Identifier      | Description            |
+| --------------- | ---------------------- |
+| `bold`          | **Bold** text.         |
+| `italic`        | _Italic_ text.         |
+| `strikethrough` | ~~Strikethrough~~ text |
+| `heading1`      | Heading 1 (H1)         |
+| `heading2`      | Heading 2 (H2)         |
+| `heading3`      | Heading 3 (H3)         |
+| `ulist`         | Unordered list         |
+| `olist`         | Ordered list           |
+| `table`         | Table markdown         |
+| `image`         | Image markdown         |
+| `quote`         | Blockquote markdown    |
+| `code`          | Code highlight         |
+| `hr`            | Horizontal rule        |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "yamde",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yamde",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "description": "Yet another markdown editor.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/Yamde.tsx
+++ b/src/Yamde.tsx
@@ -15,7 +15,7 @@ const converter = new Showdown.Converter({
   noHeaderId: true,
 })
 
-const Yamde = ({ value, handler }: Omit<Props, 'theme'>) => {
+const Yamde = ({ value, handler, toolbar }: Omit<Props, 'theme'>) => {
   const [isPreviewMode, setisPreviewMode] = useState(false)
   const textEditor = useRef<HTMLTextAreaElement>(null)
   const classes = useStyles()
@@ -74,17 +74,19 @@ const Yamde = ({ value, handler }: Omit<Props, 'theme'>) => {
     <div className={classes.yamde}>
       <div className={classes.toolbar}>
         <div className={classes.buttons}>
-          {toolbarActions.map(({ name, icon, schema }) => {
-            return (
-              <div
-                key={name}
-                className={classes.button}
-                onClick={() => handleClick({ name, schema })}
-              >
-                {icon}
-              </div>
-            )
-          })}
+          {toolbarActions
+            .filter((action) => toolbar?.includes(action.name))
+            .map(({ name, icon, schema }) => {
+              return (
+                <div
+                  key={name}
+                  className={classes.button}
+                  onClick={() => handleClick({ name, schema })}
+                >
+                  {icon}
+                </div>
+              )
+            })}
         </div>
         <div className={classes.viewSwitch}>
           <div

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -7,10 +7,12 @@ import Yamde from './Yamde'
 import { lightTheme } from './themes/light'
 import { darkTheme } from './themes/dark'
 
-const YamdeComp = ({ value, handler, theme = 'light' }: Props) => {
+import { defaultToolbarAction } from './utils/defaultToolbarActions'
+
+const YamdeComp = ({ value, handler, theme = 'light', toolbar = defaultToolbarAction }: Props) => {
   return (
     <ThemeProvider theme={theme === 'light' ? lightTheme : darkTheme}>
-      <Yamde value={value} handler={handler} />
+      <Yamde value={value} handler={handler} toolbar={toolbar} />
     </ThemeProvider>
   )
 }

--- a/src/types/Props.ts
+++ b/src/types/Props.ts
@@ -4,6 +4,7 @@ interface Props {
   value: string
   handler: (param: string) => void
   theme?: Theme
+  toolbar?: string[]
 }
 
 export default Props

--- a/src/utils/defaultToolbarActions.ts
+++ b/src/utils/defaultToolbarActions.ts
@@ -1,0 +1,16 @@
+export const defaultToolbarAction = [
+  'bold',
+  'italic',
+  'strikethrough',
+  'heading1',
+  'heading2',
+  'heading3',
+  'ulist',
+  'olist',
+  'table',
+  'image',
+  'link',
+  'quote',
+  'code',
+  'hr',
+]


### PR DESCRIPTION
Resolves #2 (enhancement request).

You can customize the toolbar actions by passing in the `toolbar` prop (`toolbar?: string[]`).
Omiting this prop will default to showing all available actions.

```jsx
<Yamde value={text} handler={setText} toolbar={['bold', 'italic', 'strikethrough']} />
```

Available actions:

| Identifier      | Description            |
| --------------- | ---------------------- |
| `bold`          | **Bold** text.         |
| `italic`        | _Italic_ text.         |
| `strikethrough` | ~~Strikethrough~~ text |
| `heading1`      | Heading 1 (H1)         |
| `heading2`      | Heading 2 (H2)         |
| `heading3`      | Heading 3 (H3)         |
| `ulist`         | Unordered list         |
| `olist`         | Ordered list           |
| `table`         | Table markdown         |
| `image`         | Image markdown         |
| `quote`         | Blockquote markdown    |
| `code`          | Code highlight         |
| `hr`            | Horizontal rule        |